### PR TITLE
Name changes

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name="ReportGenerator",  # the name of the project EEG-ns-COOP 
+    name="report_generator",
     version="1.0",
     # mandatory
     author_email="fangfangsheng46@gmail.com",


### PR DESCRIPTION
`report_generator` is, I think, the Pythonic way of writing a package name.

I would also suggest sticking to `snake_case`, which will help keep your package in line with Python conventions.